### PR TITLE
Create personal marketing site for Nelson Jerónimo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Nelson Jerónimo | AI & Software Engagement Leader</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero" id="top">
+    <div class="hero__content">
+      <p class="hero__eyebrow">Nelson Jerónimo</p>
+      <h1 class="hero__title">Accelerating innovation with human-centered software and AI delivery</h1>
+      <p class="hero__subtitle">Engagement Manager at Axians | Former Product Owner at VOID Software. I help leadership teams design, build, and scale intelligent products that move the bottom line.</p>
+      <div class="hero__cta">
+        <a class="button button--primary" href="#contact">Start a conversation</a>
+        <a class="button button--ghost" href="mailto:nelson.jeronimo@axians.com">nelson.jeronimo@axians.com</a>
+      </div>
+    </div>
+    <div class="hero__badge">
+      <span>10+ years guiding digital product teams</span>
+    </div>
+  </header>
+
+  <main>
+    <section class="section section--alt" id="value">
+      <div class="section__content">
+        <h2>Where vision meets execution</h2>
+        <p>I translate ambitious business goals into clear delivery roadmaps, align multi-disciplinary teams, and ensure every sprint creates measurable value. From discovery to deployment, I bring structure, transparency, and a passion for customer outcomes.</p>
+        <div class="pill-grid">
+          <span class="pill">Strategic discovery &amp; alignment</span>
+          <span class="pill">Product delivery leadership</span>
+          <span class="pill">AI opportunity mapping</span>
+          <span class="pill">Stakeholder communication</span>
+          <span class="pill">Data-informed decision making</span>
+          <span class="pill">Change management</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="experience">
+      <div class="section__header">
+        <h2>Professional journey</h2>
+        <p>Trusted partner to enterprises and scale-ups navigating software and AI transformation.</p>
+      </div>
+      <div class="timeline">
+        <article class="timeline__item">
+          <div class="timeline__period">2023 — Present</div>
+          <div class="timeline__body">
+            <h3>Axians &mdash; Engagement Manager</h3>
+            <ul>
+              <li>Lead end-to-end engagements delivering AI-augmented solutions for industries including energy, finance, and public services.</li>
+              <li>Shape delivery squads by pairing product strategy, data science, and engineering talent around client goals.</li>
+              <li>Advise executives on operating models that sustain innovation and accelerate time-to-value.</li>
+            </ul>
+          </div>
+        </article>
+        <article class="timeline__item">
+          <div class="timeline__period">2016 — 2023</div>
+          <div class="timeline__body">
+            <h3>VOID Software &mdash; Product Owner</h3>
+            <ul>
+              <li>Guided product strategy for mission-critical applications in aerospace, finance, and telecommunications.</li>
+              <li>Championed customer-centric roadmaps by converting user research, analytics, and stakeholder feedback into prioritized backlogs.</li>
+              <li>Scaled agile practices that boosted delivery predictability and team satisfaction.</li>
+            </ul>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section section--alt" id="services">
+      <div class="section__header">
+        <h2>How we can work together</h2>
+        <p>Flexible collaboration models for leaders ready to unlock software and AI potential.</p>
+      </div>
+      <div class="cards">
+        <article class="card">
+          <h3>Innovation Roadmapping</h3>
+          <p>Assess current capabilities, identify high-impact opportunities, and deliver a pragmatic execution plan.</p>
+          <ul>
+            <li>AI readiness assessment</li>
+            <li>North-star metrics definition</li>
+            <li>Stakeholder alignment workshops</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3>Product Delivery Leadership</h3>
+          <p>Embed seasoned product guidance to keep teams focused, collaborative, and shipping.</p>
+          <ul>
+            <li>Outcome-driven roadmaps</li>
+            <li>Backlog prioritization &amp; refinement</li>
+            <li>Execution governance</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3>AI Solution Orchestration</h3>
+          <p>Partner with data and engineering experts to deliver responsible AI solutions tailored to your domain.</p>
+          <ul>
+            <li>Use case ideation &amp; validation</li>
+            <li>Experimentation frameworks</li>
+            <li>Change enablement &amp; training</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="proof">
+      <div class="section__header">
+        <h2>What partners say</h2>
+        <p>Feedback from teams who value clarity, empathy, and business impact.</p>
+      </div>
+      <div class="quote-grid">
+        <figure class="quote">
+          <blockquote>
+            “Nelson has a rare ability to unite technical and business stakeholders around a shared vision. His facilitation brought momentum to a complex transformation.”
+          </blockquote>
+          <figcaption>Program Director, European Energy Company</figcaption>
+        </figure>
+        <figure class="quote">
+          <blockquote>
+            “From the first discovery workshop, Nelson mapped our challenges and translated them into an actionable roadmap. The delivery cadence and transparency were exceptional.”
+          </blockquote>
+          <figcaption>CTO, Digital Payments Scale-Up</figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section class="section section--alt" id="insights">
+      <div class="section__header">
+        <h2>Insights &amp; speaking topics</h2>
+        <p>Invite me to share pragmatic lessons on building smarter products.</p>
+      </div>
+      <div class="topic-list">
+        <article>
+          <h3>Designing AI initiatives that ship</h3>
+          <p>From discovery to deployment: how to keep teams aligned on outcomes and ethics.</p>
+        </article>
+        <article>
+          <h3>Human-centered delivery leadership</h3>
+          <p>Tools for driving high-trust collaboration across engineering, design, and business stakeholders.</p>
+        </article>
+        <article>
+          <h3>Product operating models for scale</h3>
+          <p>Balancing experimentation and governance to accelerate value in regulated industries.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="contact">
+      <div class="contact">
+        <div class="contact__intro">
+          <h2>Let’s build what’s next</h2>
+          <p>Whether you are exploring AI, scaling a product team, or need a sparring partner for your roadmap, I’m ready to help.</p>
+        </div>
+        <form class="contact__form" action="https://formspree.io/f/xbjnpryk" method="POST">
+          <label for="name">Name</label>
+          <input id="name" name="name" type="text" placeholder="Jane Smith" required>
+
+          <label for="email">Email</label>
+          <input id="email" name="email" type="email" placeholder="you@company.com" required>
+
+          <label for="message">How can I help?</label>
+          <textarea id="message" name="message" rows="4" placeholder="Tell me about your initiative" required></textarea>
+
+          <button class="button button--primary" type="submit">Send message</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer__content">
+      <p>© <span id="year"></span> Nelson Jerónimo. All rights reserved.</p>
+      <div class="footer__links">
+        <a href="https://www.linkedin.com/in/nelsonjeronimo/" target="_blank" rel="noopener">LinkedIn</a>
+        <a href="mailto:nelson.jeronimo@axians.com">Email</a>
+      </div>
+    </div>
+  </footer>
+
+  <a href="#top" class="scroll-top" aria-label="Back to top">↑</a>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,18 @@
+const yearEl = document.getElementById('year');
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}
+
+const scrollTop = document.querySelector('.scroll-top');
+if (scrollTop) {
+  const toggle = () => {
+    if (window.scrollY > 400) {
+      scrollTop.classList.add('visible');
+    } else {
+      scrollTop.classList.remove('visible');
+    }
+  };
+
+  window.addEventListener('scroll', toggle);
+  toggle();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,405 @@
+:root {
+  color-scheme: light dark;
+  --bg: #060814;
+  --bg-alt: #0f1324;
+  --text: #f5f7ff;
+  --text-muted: rgba(245, 247, 255, 0.72);
+  --accent: #67e8f9;
+  --accent-strong: #06b6d4;
+  --card-bg: rgba(9, 11, 25, 0.85);
+  --border: rgba(103, 232, 249, 0.25);
+  --pill-bg: rgba(255, 255, 255, 0.08);
+  --quote-bg: rgba(103, 232, 249, 0.07);
+  --shadow: 0 25px 70px rgba(6, 182, 212, 0.15);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top left, rgba(103, 232, 249, 0.18), transparent 45%),
+              radial-gradient(circle at top right, rgba(14, 165, 233, 0.22), transparent 40%),
+              var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.hero {
+  position: relative;
+  padding: 8rem clamp(1.5rem, 5vw, 6rem) 5rem;
+  display: grid;
+  gap: 2.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 2rem;
+  border-radius: 2rem;
+  background: linear-gradient(135deg, rgba(103, 232, 249, 0.3), transparent 55%);
+  filter: blur(60px);
+  z-index: -2;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 2.5rem;
+  border: 1px solid var(--border);
+  background: rgba(6, 8, 20, 0.8);
+  backdrop-filter: blur(24px);
+  z-index: -1;
+}
+
+.hero__eyebrow {
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+  font-weight: 800;
+  line-height: 1.1;
+  margin-bottom: 1.5rem;
+}
+
+.hero__subtitle {
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  max-width: 45ch;
+}
+
+.hero__cta {
+  margin-top: 2.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero__badge {
+  justify-self: end;
+  align-self: end;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 0.85rem 1.75rem;
+  font-weight: 600;
+  color: var(--accent);
+  background: rgba(6, 182, 212, 0.12);
+  box-shadow: var(--shadow);
+}
+
+.button {
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #04111f;
+  box-shadow: var(--shadow);
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  transform: translateY(-2px);
+}
+
+.button--ghost {
+  border: 1px solid var(--border);
+  background: transparent;
+}
+
+main {
+  display: grid;
+  gap: 5rem;
+  padding: 0 1.5rem 5rem;
+}
+
+.section {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+}
+
+.section--alt {
+  background: rgba(10, 13, 30, 0.6);
+  padding: 4rem clamp(1.5rem, 4vw, 4rem);
+  border-radius: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.section__header h2,
+.section__content h2 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+}
+
+.section__header p,
+.section__content p {
+  color: var(--text-muted);
+  max-width: 60ch;
+}
+
+.pill-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+.pill {
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  background: var(--pill-bg);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 1.5rem;
+  position: relative;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 0.7rem;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  width: 2px;
+  background: linear-gradient(180deg, transparent, var(--accent), transparent);
+}
+
+.timeline__item {
+  padding-left: 2.5rem;
+  position: relative;
+}
+
+.timeline__item::before {
+  content: "";
+  position: absolute;
+  left: 0.1rem;
+  top: 0.35rem;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  border: 2px solid var(--accent);
+  background: var(--bg);
+  box-shadow: 0 0 0 6px rgba(6, 182, 212, 0.08);
+}
+
+.timeline__period {
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+}
+
+.timeline__body h3 {
+  font-size: 1.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.timeline__body ul {
+  display: grid;
+  gap: 0.75rem;
+  color: var(--text-muted);
+}
+
+.cards {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1rem;
+}
+
+.card ul {
+  display: grid;
+  gap: 0.5rem;
+  color: var(--text-muted);
+}
+
+.quote-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.quote {
+  background: var(--quote-bg);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  border: 1px solid rgba(103, 232, 249, 0.1);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.25);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.quote blockquote {
+  font-size: 1.05rem;
+  font-style: italic;
+  color: var(--text);
+}
+
+.quote figcaption {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.topic-list {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.topic-list article {
+  background: rgba(9, 11, 25, 0.7);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.topic-list p {
+  color: var(--text-muted);
+}
+
+.contact {
+  background: rgba(9, 11, 25, 0.9);
+  border-radius: 2rem;
+  padding: clamp(2rem, 4vw, 3.5rem);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
+}
+
+.contact__intro h2 {
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.contact__intro p {
+  color: var(--text-muted);
+}
+
+.contact__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact__form label {
+  font-weight: 600;
+}
+
+.contact__form input,
+.contact__form textarea {
+  background: rgba(6, 8, 20, 0.7);
+  border: 1px solid rgba(103, 232, 249, 0.2);
+  border-radius: 0.9rem;
+  padding: 0.85rem 1rem;
+  color: var(--text);
+  font: inherit;
+  resize: vertical;
+}
+
+.contact__form input:focus,
+.contact__form textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(103, 232, 249, 0.15);
+}
+
+.footer {
+  padding: 2rem 1.5rem 3rem;
+}
+
+.footer__content {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  color: var(--text-muted);
+}
+
+.footer__links {
+  display: flex;
+  gap: 1rem;
+}
+
+.scroll-top {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  background: rgba(9, 11, 25, 0.85);
+  color: var(--accent);
+  font-size: 1.4rem;
+  box-shadow: 0 18px 40px rgba(6, 182, 212, 0.2);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.scroll-top.visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(-6px);
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding-top: 6rem;
+  }
+
+  .hero__badge {
+    justify-self: start;
+  }
+
+  .section--alt {
+    padding: 3rem 1.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- build a single-page marketing site for Nelson Jerónimo with hero, value, experience, services, testimonials, insights, and contact sections
- add modern dark-neon design system with responsive layout and animated scroll-to-top control
- include dynamic copyright year script and embedded contact form via Formspree

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de30f253548326905429df1bb53b7d